### PR TITLE
docker-hub-cli追加

### DIFF
--- a/hub-tool
+++ b/hub-tool
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+if [ ! -d ~/.docker-hub-cli ]; then
+  mkdir -p ~/.docker-hub-cli/.ssh
+fi
+
+tempdir=$(mktemp -d) || exit 1
+
+cat <<DOCKERFILE | docker build $tempdir -t docker-hub-cli -f - &> /dev/null
+# 1.17超過のバージョンでは外部ライブラリは参照しなくなっている
+FROM golang:1.17
+
+ENV GO111MODULE=on
+RUN go get github.com/docker/hub-tool
+
+# RUN useradd -m -u $(id -u) -U -d /cli -p '' cli
+RUN adduser --disabled-password --uid $(id -u) --home /cli cli
+
+ENTRYPOINT [ "hub-tool" ]
+DOCKERFILE
+
+docker run \
+  -u $(id -u):$(id -g) \
+  -v $(pwd):$(pwd) \
+  --workdir $(pwd) --rm -it \
+  -v  ~/.docker-hub-cli:/cli \
+  -v ~/.ssh:/cli/.ssh \
+  docker-hub-cli \
+  "$@"


### PR DESCRIPTION
- docker-hub-cliを追加した
- docker-hubにアカウントがあることが前提
- 苦労した点： 
  - golangのライブラリ仕様が変わっててマニュアルどおりにコンパイルできなかった。
  - 実行バイナリの方はバージョンがURL中に含まれているので不採用
- 使用例

```sh
$ hub-tool login                                                                                          <aws:n9d>
Username: n9dn9d
Password: 
Login Succeeded

$ hub-tool tag ls mysql                                                                                   <aws:n9d>
TAG                        DIGEST                                                                     STATUS      LAST UPDATE      LAST PUSHED    LAST PULLED       SIZE
mysql:latest               sha256:c458b26f2f9f9fe086ed75d1f8db8e2dde371801403f2c7da9be4fb228a2944a    active      5 days ago       5 days         21 minutes        359MB
mysql:8.0                  sha256:8b8835a2c32cd7357a5d2ea4b49ad870ff519c8c1d4add362803feddf4a0a973    active      5 days ago       5 days         20 minutes        358.5MB
```